### PR TITLE
Add fragment init to release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,14 @@ jobs:
           brew install --build-from-source ./Formula/fragment-cli-beta.rb
           echo "Fragment CLI installed"
           fragment --version
+          fragment init
       - name: Brew Install Fragment CLI Prod on ${{ matrix.os }}
         if: ${{ github.event.client_payload.stage == 'prod' }}
         run: |
           brew install --build-from-source ./Formula/fragment-cli.rb
           echo "Fragment CLI installed"
           fragment --version
+          fragment init
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
```

❯ fragment init
 ›   ModuleLoadError: [MODULE_NOT_FOUND] require failed to load /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/dist/commands/init.js: Cannot find module 'tslib'
 ›   Require stack:
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/dist/lib/baseCommand.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/dist/commands/init.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/module-loader.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/help/index.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/flags.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/cli-ux/styled/table.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/cli-ux/styled/index.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/cli-ux/index.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/node_modules/@oclif/core/lib/index.js
 ›   - /opt/homebrew/Cellar/fragment-cli-beta/3955.2.0/libexec/bin/run
 ›   Code: MODULE_NOT_FOUND
~/fragment/workspaces/scripts on dev *8 !3 ❯ gst
```
This command reproduces the error