### PR TITLE
Enable corepack in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           app_id: ${{ secrets.PR_APP_ID }}
           private_key: ${{ secrets.PR_APP_PRIVATE_KEY }}
 
+      - name: Enable corepack
+        id: enable-corepack
+        run: corepack enable
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The latest yarn (1.22.21) has broken something:

```
~/fragment/homebrew-tap$ yarn --version
1.22.19
~/fragment/homebrew-tap$ yarn test
yarn run v1.22.19
warning ../../package.json: No license field
$ echo hi
hi
✨  Done in 0.02s.
~/fragment/homebrew-tap$ npm install --global yarn

changed 1 package in 732ms
~/fragment/homebrew-tap$ yarn --version
1.22.21
~/fragment/homebrew-tap$ yarn test
error This project's package.json defines "packageManager": "yarn@3.2.1". However the current global version of Yarn is 1.22.21.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
```

This does resolve locally by enabling corepack:

```
~/fragment/homebrew-tap$ corepack enable
~/fragment/homebrew-tap$ yarn test
hi
```

so trying to add this as a step. Others have been reporting this issue as well so there might be a better fix at some point https://github.com/yarnpkg/yarn/issues/9015#issuecomment-1821658384