### PR TITLE
Update CLI Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
           echo "Fragment CLI installed"
           fragment --version
           fragment init -f ${{ github.run_id }}-prod.jsonc
-          rm ${{ github.run_id }}-prod.jsonc
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Now that we're no longer supporting CLI-based schema development, we don't need the `rm` step which causes the action to fail.