### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Homebrew Release
+permissions:
+  contents: read
+  pull-requests: write
 on:
   repository_dispatch:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/fragment-dev/homebrew-tap/security/code-scanning/1](https://github.com/fragment-dev/homebrew-tap/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow interacts with repository contents and creates pull requests, we can set `contents: read` and `pull-requests: write` as the permissions. These permissions will apply to all jobs in the workflow unless overridden by job-specific permissions.

The `permissions` block should be added at the root level of the workflow file, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
