### PR TITLE
Bump minimatch and ajv to fix Dependabot alerts

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -485,14 +485,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^6.10.2":
-  version: 6.12.6
-  resolution: "ajv@npm:6.12.6"
+  version: 6.14.0
+  resolution: "ajv@npm:6.14.0"
   dependencies:
     fast-deep-equal: ^3.1.1
     fast-json-stable-stringify: ^2.0.0
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
-  checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  checksum: 7bb3ea97bb8af52521589079f427e799b6561acaa94f50e13410cb87588c51df8db1afe1157b3e48f1a829269adaa11116e0c2cafe2b998add1523789809a3c5
   languageName: node
   linkType: hard
 
@@ -1358,11 +1358,11 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^3.1.1":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: ^1.1.7
-  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  checksum: 47ef6f412c08be045a7291d11b1c40777925accf7252dc6d3caa39b1bfbb3a7ea390ba7aba464d762d783265c644143d2c8a204e6b5763145024d52ee65a1941
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Refreshes `minimatch` from 3.1.2 to 3.1.5 (transitive dep via `@caporal/core` → `glob`), fixing 3 high-severity ReDoS alerts
- Refreshes `ajv` from 6.12.6 to 6.14.0 (transitive dep via `@caporal/core` → `table`), fixing 1 medium-severity ReDoS alert
- No new resolutions added — just lockfile refresh within existing semver ranges

## Alerts fixed
| # | Severity | Package | Summary |
|---|----------|---------|---------|
| 20 | medium | ajv | ReDoS when using `$data` option |
| 21 | high | minimatch | ReDoS via repeated wildcards |
| 22 | high | minimatch | ReDoS via multiple GLOBSTAR segments |
| 23 | high | minimatch | ReDoS via nested extglobs |

## Test plan
- [ ] `yarn update-fragment-cli-version` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)