### PR TITLE
Symlink Homebrew's node@20 into the CLI install

### DIFF
--- a/templates/fragment-cli-beta.rb
+++ b/templates/fragment-cli-beta.rb
@@ -22,6 +22,10 @@ class FragmentCliBeta < Formula
   def install
     inreplace "bin/fragment", /^CLIENT_HOME=/, "export FRAGMENT_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]
+    # The tarball ships without a Node runtime; point the launcher's
+    # $DIR/node lookup at Homebrew's keg-only node@20.
+    rm_f libexec/"bin/node"
+    (libexec/"bin").install_symlink Formula["node@20"].opt_bin/"node" => "node"
     bin.install_symlink libexec/"bin/fragment"
   end
 

--- a/templates/fragment-cli.rb
+++ b/templates/fragment-cli.rb
@@ -22,6 +22,10 @@ class FragmentCli < Formula
   def install
     inreplace "bin/fragment", /^CLIENT_HOME=/, "export FRAGMENT_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
     libexec.install Dir["*"]
+    # The tarball ships without a Node runtime; point the launcher's
+    # $DIR/node lookup at Homebrew's keg-only node@20.
+    rm_f libexec/"bin/node"
+    (libexec/"bin").install_symlink Formula["node@20"].opt_bin/"node" => "node"
     bin.install_symlink libexec/"bin/fragment"
   end
 


### PR DESCRIPTION
Companion to [fragment-dev/workspaces#11842](https://github.com/fragment-dev/workspaces/pull/11842), which strips the embedded Node runtime (and yarn staging cruft) from the CLI tarballs — dropping them from ~40MB to ~5.4MB.

## What changed

Both formula templates now, after installing the tarball into `libexec`:

```ruby
rm_f libexec/"bin/node"
(libexec/"bin").install_symlink Formula["node@20"].opt_bin/"node" => "node"
```

The launcher script (`bin/fragment`) prefers a `node` binary sitting next to itself before falling back to PATH. The formula already declares `depends_on "node@20"`, but node@20 is **keg-only** (not linked into PATH), so the symlink is what reliably connects the launcher to Homebrew's node once the tarball stops embedding one.

## Merge-order safety

`rm_f` first makes this order-independent:
- **Fat tarball** (released before workspaces#11842 merges): embedded node gets replaced by the symlink — identical behavior, brew's node@20 matches the previously embedded major.
- **Slim tarball** (after): `rm_f` is a no-op, symlink provides node.

So this can merge before the workspaces PR — and should, so the next dev release that ships slim tarballs regenerates `fragment-cli-beta` from a template that already handles them.

Note `Formula/*.rb` are regenerated from these templates on the next release webhook; they are intentionally not hand-edited here.

## Validation plan

After the next dev release with slim tarballs: `brew install fragment-dev/tap/fragment-cli-beta && fragment version`, plus `fragment verify-schema` on a sample schema. Prod formula follows the next promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
