### PR TITLE
Bump handlebars to 4.7.9 and tmp to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
   },
   "dependencies": {
     "@caporal/core": "^2.0.7",
-    "handlebars": "^4.7.7",
+    "handlebars": "^4.7.9",
     "octokit": "^3.2.2",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.6"
   },
   "packageManager": "yarn@3.2.1",
   "resolutions": {
     "brace-expansion": "1.1.12",
     "lodash": "4.17.23",
-    "tmp": "0.2.4"
+    "tmp": "0.2.6"
   },
   "devDependencies": {
     "@types/tmp": "^0.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,12 +1091,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.7":
-  version: 4.7.7
-  resolution: "handlebars@npm:4.7.7"
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: ^1.2.5
-    neo-async: ^2.6.0
+    neo-async: ^2.6.2
     source-map: ^0.6.1
     uglify-js: ^3.1.4
     wordwrap: ^1.0.0
@@ -1105,7 +1105,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 1e79a43f5e18d15742977cb987923eab3e2a8f44f2d9d340982bcb69e1735ed049226e534d7c1074eaddaf37e4fb4f471a8adb71cddd5bc8cf3f894241df5cee
+  checksum: ac39070fc1c3c76a654e4b526383eaf1601976eaa474547b263915b4806977f083600e586ca923709baeed7c82a42640bcc9cc04c37a7efd3fb444f49b8347d6
   languageName: node
   linkType: hard
 
@@ -1131,9 +1131,9 @@ __metadata:
     "@types/tmp": ^0.2.3
     esbuild: ^0.15.13
     esbuild-runner: ^2.2.2
-    handlebars: ^4.7.7
+    handlebars: ^4.7.9
     octokit: ^3.2.2
-    tmp: ^0.2.4
+    tmp: ^0.2.6
     typescript: ^4.8.4
   languageName: unknown
   linkType: soft
@@ -1405,7 +1405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.0":
+"neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: deac9f8d00eda7b2e5cd1b2549e26e10a0faa70adaa6fdadca701cc55f49ee9018e427f424bac0c790b7c7e2d3068db97f3093f1093975f2acb8f8818b936ed9
@@ -1716,10 +1716,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.4":
-  version: 0.2.4
-  resolution: "tmp@npm:0.2.4"
-  checksum: fde5fcdbd741c957458d6f7310750879172b399ac62b468c6707cef6fd0e77d0e632dd05471f607530a248c483abaa00187a6eee8561030268ac98bfb5e41720
+"tmp@npm:0.2.6":
+  version: 0.2.6
+  resolution: "tmp@npm:0.2.6"
+  checksum: 9e6255b922ab8c6e70b3271e246a14a2f0ad844e951642b34a28bb533d37fbc74f043c7112bceb72be96eded4644a3f3dc67d1934e8593f6a0cb050ffc13e64a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `handlebars` from `^4.7.7` to `^4.7.9` (fixes Dependabot alerts #24, #25, #26, #27, #28, #31 — prototype pollution and JS injection via AST type confusion)
- Bumps `tmp` from `^0.2.4` to `^0.2.6` (fixes Dependabot alert #34 — path traversal via unsanitized prefix/postfix)
- Updates the `tmp` resolution in `package.json` to match
- Dismissed `lodash` (#32, #33) and `brace-expansion` (#35) as tolerable risk (transitive via `@caporal/core`/`inquirer`; `lodash.template` not called with user-controlled input)

## Test plan
- [ ] `yarn` runs without errors
- [ ] `node_modules/handlebars/package.json` version is 4.7.9
- [ ] `node_modules/tmp/package.json` version is 0.2.6
- [ ] Dependabot alerts clear after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)